### PR TITLE
Fix om värstafallstid

### DIFF
--- a/ovn3.md
+++ b/ovn3.md
@@ -58,7 +58,7 @@ dvs använda högst *O*(1) extra utrymme. *Du får inte använda någon sorterin
 
 För betyg VG ska du göra samma uppgifter som för betyg G,
 men med det extra kravet att algoritmerna i **uppgift 3.2 och 3.3** ska ha *O*(*n*) tidskomplexitet.
-Det räcker med förväntad (expected) tid, men värstafall går förstås också bra. (Linjär värstafallstid är svårt men inte helt omöjligt.)
+Det räcker med förväntad (expected) tid, men värstafall går förstås också bra. (Linjär värstafallstid är svårt men inte helt omöjligt för 3.3.)
 
 På engelska skiljer man på **average** time complexity där man väger samman tiderna för alla möjliga indata och  **expected** time complexity där algoritmen använder sig av slump för att göra värstafallsbeteendet extremt osannolikt. Vi har sett två exempel på expected time hittils i kursen: hashtabeller och treapar. På svenska finns det tyvärr ingen tydlig och bra terminologi.
 


### PR DESCRIPTION
Det framgår av uppgiftsbeskrivningen för betyg VG att linjär värstfallstid är "svårt men inte omöjligt", implicit för både uppgift 3.2 och 3.3. Men, enligt https://stackoverflow.com/questions/4168622/computing-the-mode-most-frequent-element-of-a-set-in-linear-time och satser på Wikipedia (Element distinctness problem), bl.a. så finns det ingen lösning som ger värstafallstidskomplexitet O(n).

Den tidigare formuleringen var missvisande, och kan leda till att mycket onödig tid läggs på att försöka hitta en sådan lösning för 3.2. Jag la mycket onödig tid på detta, t.ex. ;P